### PR TITLE
Update `liblapack_name` to the one from `LinearAlgebra.BLAS`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LowRankApprox"
 uuid = "898213cb-b102-5a47-900c-97e73b919f73"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -5,7 +5,7 @@ module _LAPACK
 import LinearAlgebra.BLAS: @blasfunc
 using LinearAlgebra: BlasFloat, BlasInt, chkstride1
 import Base: Nothing
-const liblapack = Base.liblapack_name
+const liblapack = LinearAlgebra.BLAS.liblapack
 
 for (geqrf, gelqf, orgqr, orglq, elty) in
       ((:sgeqrf_, :sgelqf_, :sorgqr_, :sorglq_, :Float32   ),

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -2,6 +2,7 @@
 =#
 
 module _LAPACK
+import LinearAlgebra
 import LinearAlgebra.BLAS: @blasfunc
 using LinearAlgebra: BlasFloat, BlasInt, chkstride1
 import Base: Nothing


### PR DESCRIPTION
`Base.liblapack_name` is deprecated (see https://github.com/JuliaLang/julia/pull/50699)