### PR TITLE
Use the truncated QR LAPACK routine `geqp3rk` as the backend for the partial qr factorization. fixes #60

### DIFF
--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -142,7 +142,7 @@ end
 for (geqp3rk, elty, relty) in ((:sgeqp3rk_,:Float32,:Float32),
                                (:dgeqp3rk_,:Float64,:Float64),
                                (:cgeqp3rk_,:ComplexF32,:Float32),
-                               (:zgeqp3rk_,:ComplexF32,:Float64))
+                               (:zgeqp3rk_,:ComplexF64,:Float64))
   @eval begin
     function geqp3rk!(
       A::AbstractMatrix{$elty},
@@ -185,8 +185,8 @@ for (geqp3rk, elty, relty) in ((:sgeqp3rk_,:Float32,:Float32),
                         Ref{BlasInt}, #n
                         Ref{BlasInt}, #nrhs
                         Ref{BlasInt},#kmax
-                        Ref{$elty},  #abstol
-                        Ref{$elty},  #reltol
+                        Ref{$relty},  #abstol
+                        Ref{$relty},  #reltol
                         Ptr{$elty},   #A
                         Ref{BlasInt}, #lda
                         Ptr{BlasInt}, #k


### PR DESCRIPTION
The LAPACK routine `geqpr3k` available starting in v3.12.0 computes the truncated QR factorization based on one of three stopping conditions. This PR adds a backend for `pqr` that uses the LAPACK routine instead of the Julia native backend in the function `geqp3_adap_main!`. This backend is faster than using the current implementation. 

There is still one unresolved issue that I need help with. When a max rank to truncate at is not provided, the `R` factor from the lapack backend differs from the current version and I am not sure why. Fixes #60 